### PR TITLE
Add CDC demo scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - working-directory: backend
+        run: |
+          npm ci
+          npm test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# E-commerce CDC Demo
+
+```
+PostgreSQL 16 --(logical decoding)--> Debezium 3.1 --> Kafka 4.0 (KRaft)
+                    ▲                        │
+                    │                        ▼
+React dashboard <-- WebSocket -- Node 20 LTS consumer
+```
+
+This project shows a minimal change-data-capture pipeline. Product stock
+changes in PostgreSQL are streamed through Debezium into Kafka and pushed to a
+React dashboard via WebSockets.
+
+## Quick start
+
+```bash
+# start everything
+docker compose up -d
+# register connector (once)
+chmod +x db-init/register-debezium.sh
+./db-init/register-debezium.sh
+```
+
+Place an order using `psql` to watch stock updates live:
+
+```sql
+INSERT INTO orders DEFAULT VALUES RETURNING id; -- note the id
+INSERT INTO order_items VALUES (<id>, 1, 2);
+```
+
+Open [http://localhost:3000](http://localhost:3000) to see the dashboard.
+
+![Dashboard](docs/dashboard.gif)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json jest.config.js ./
+RUN npm install --production
+COPY src ./src
+CMD ["node", "--loader", "ts-node/esm", "src/index.ts"]

--- a/backend/__tests__/sanity.test.ts
+++ b/backend/__tests__/sanity.test.ts
@@ -1,0 +1,5 @@
+describe('sanity', () => {
+  it('works', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ecommerce-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node --loader ts-node/esm src/index.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "kafkajs": "^2.2.4",
+    "ws": "^8.13.0",
+    "typescript": "^5.2.0",
+    "ts-node": "^10.9.1",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "@types/jest": "^29.5.1",
+    "ts-jest": "^29.1.0"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,45 @@
+import { Kafka } from 'kafkajs';
+import { WebSocketServer } from 'ws';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const broker = process.env.KAFKA_BROKER ?? 'localhost:9092';
+const kafka = new Kafka({ brokers: [broker] });
+const consumer = kafka.consumer({ groupId: 'dashboard' });
+const topic = 'public.orders';
+
+const stock: Record<string, number> = {};
+const wss = new WebSocketServer({ port: 4000 });
+
+function broadcast() {
+  const data = JSON.stringify(stock);
+  for (const client of wss.clients) {
+    if (client.readyState === client.OPEN) client.send(data);
+  }
+}
+
+await consumer.connect();
+await consumer.subscribe({ topic, fromBeginning: true });
+
+await consumer.run({
+  eachMessage: async ({ message }: any) => {
+    const value = message.value?.toString();
+    if (!value) return;
+    console.log(value);
+    try {
+      const event = JSON.parse(value);
+      const after = event.after ?? {};
+      const productId = after.product_id;
+      const qty = after.quantity ?? 0;
+      if (productId) {
+        stock[productId] = (stock[productId] || 0) - qty;
+        broadcast();
+      }
+    } catch (err) {
+      console.error('Failed to parse message', err);
+    }
+  }
+});
+
+console.log('WebSocket server running on port 4000');

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./types", "../node_modules/@types"],
+    "outDir": "dist"
+  },
+  "include": ["src", "types"]
+}

--- a/backend/types/dotenv.d.ts
+++ b/backend/types/dotenv.d.ts
@@ -1,0 +1,1 @@
+declare module 'dotenv';

--- a/backend/types/kafkajs.d.ts
+++ b/backend/types/kafkajs.d.ts
@@ -1,0 +1,1 @@
+declare module 'kafkajs';

--- a/backend/types/node.d.ts
+++ b/backend/types/node.d.ts
@@ -1,0 +1,4 @@
+interface ProcessEnv {
+  [key: string]: string | undefined;
+}
+declare var process: { env: ProcessEnv };

--- a/backend/types/ws.d.ts
+++ b/backend/types/ws.d.ts
@@ -1,0 +1,1 @@
+declare module 'ws';

--- a/db-init/00_init.sql
+++ b/db-init/00_init.sql
@@ -1,0 +1,22 @@
+ALTER SYSTEM SET wal_level = logical;
+
+CREATE TABLE IF NOT EXISTS products (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    stock INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    order_id INT REFERENCES orders(id),
+    product_id INT REFERENCES products(id),
+    quantity INT NOT NULL
+);
+
+INSERT INTO products (name, stock) VALUES
+    ('Gadget', 10),
+    ('Widget', 5);

--- a/db-init/register-debezium.sh
+++ b/db-init/register-debezium.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+CONNECT_URL=${CONNECT_URL:-http://localhost:8083}
+
+echo "Waiting for Kafka Connect..."
+until curl -sf "$CONNECT_URL/connectors" >/dev/null; do
+  sleep 3
+done
+
+echo "Registering Debezium connector"
+curl -s -X POST -H "Content-Type: application/json" \
+  --data '{
+    "name": "postgres-ecommerce-connector",
+    "config": {
+      "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+      "plugin.name": "pgoutput",
+      "database.hostname": "postgres",
+      "database.port": "5432",
+      "database.user": "postgres",
+      "database.password": "postgres",
+      "database.dbname": "ecommerce",
+      "database.server.name": "ecommerce",
+      "slot.name": "ecommerce_slot",
+      "publication.autocreate.mode": "filtered",
+      "topic.prefix": "public",
+      "schema.include": "public"
+    }
+  }' \
+  "$CONNECT_URL/connectors"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ecommerce
+    volumes:
+      - ./db-init:/docker-entrypoint-initdb.d
+    ports:
+      - "5432:5432"
+
+  kafka:
+    image: apache/kafka:4.0.0
+    environment:
+      KAFKA_KRAFT_BROKER_ID: "1"
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    ports:
+      - "9092:9092"
+    depends_on:
+      - postgres
+
+  debezium:
+    image: debezium/connect:3.1
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      GROUP_ID: "1"
+      CONFIG_STORAGE_TOPIC: debezium_connect_configs
+      OFFSET_STORAGE_TOPIC: debezium_connect_offsets
+      STATUS_STORAGE_TOPIC: debezium_connect_statuses
+      KEY_CONVERTER_SCHEMAS_ENABLE: 'false'
+      VALUE_CONVERTER_SCHEMAS_ENABLE: 'false'
+    ports:
+      - "8083:8083"
+    depends_on:
+      - kafka
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    ports:
+      - "8080:8080"
+    depends_on:
+      - kafka
+
+  backend:
+    build: ./backend
+    environment:
+      KAFKA_BROKER: kafka:9092
+    ports:
+      - "4000:4000"
+    depends_on:
+      - kafka
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.16.1",
+    "recharts": "^2.8.0",
+    "isomorphic-ws": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "vite": "^4.4.0",
+    "@vitejs/plugin-react": "^4.1.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import WebSocket from 'isomorphic-ws';
+import { motion } from 'framer-motion';
+
+interface Stock {
+  [key: string]: number;
+}
+
+export default function App() {
+  const [stock, setStock] = useState<Stock>({});
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:4000');
+    ws.onmessage = (ev) => {
+      const data = JSON.parse(ev.data.toString());
+      setStock(data);
+    };
+    return () => ws.close();
+  }, []);
+
+  return (
+    <div>
+      <h1>Product Stock</h1>
+      {Object.entries(stock).map(([id, qty]) => (
+        <motion.div key={id} animate={{ scale: 1 }} initial={{ scale: 0.9 }}>
+          <strong>{id}</strong>: {qty}
+        </motion.div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold minimal CDC demo with docker-compose
- add PostgreSQL init scripts and Debezium connector script
- implement backend Kafka consumer and websocket broadcaster
- create simple React dashboard
- set up CI workflow

## Testing
- `tsc --noEmit -p backend`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8af44ce88327b690f4807d9d6558