### PR TITLE
Fix CI workflow for backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
   pull_request:
 
 jobs:
-  test:
+  backend-tests:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
     steps:
       - uses: actions/checkout@v3
 
@@ -20,15 +23,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
-        run: |
-          if [ -f package-lock.json ]; then
-            npm ci
-          elif [ -f package.json ]; then
-            npm install
-          fi
+        run: npm ci
 
       - name: Run backend tests
         env:


### PR DESCRIPTION
## Summary
- fix CI workflow so it runs from the `backend` folder
- update Node version to 20

## Testing
- `npm ci --prefix backend` *(fails: network access blocked)*
- `npm test --prefix backend` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f02fcede08327a1b693be405be581