### PR TITLE
Improve backend startup

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,6 @@
 import { Kafka } from 'kafkajs';
 import { WebSocketServer } from 'ws';
+import http from 'http';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -8,9 +9,21 @@ const broker = process.env.KAFKA_BROKER ?? 'localhost:9092';
 const kafka = new Kafka({ brokers: [broker] });
 const consumer = kafka.consumer({ groupId: 'dashboard' });
 const topic = 'public.orders';
+const admin = kafka.admin();
 
 const stock: Record<string, number> = {};
-const wss = new WebSocketServer({ port: 4000 });
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200);
+    res.end('ok');
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+
+const wss = new WebSocketServer({ server });
 
 function broadcast() {
   const data = JSON.stringify(stock);
@@ -21,7 +34,20 @@ function broadcast() {
   }
 }
 
+async function ensureTopic() {
+  await admin.connect();
+  const topics = await admin.listTopics();
+  if (!topics.includes(topic)) {
+    await admin.createTopics({
+      topics: [{ topic }],
+      waitForLeaders: true,
+    });
+  }
+  await admin.disconnect();
+}
+
 async function main() {
+  await ensureTopic();
   await consumer.connect();
   await consumer.subscribe({ topic, fromBeginning: true });
 
@@ -44,8 +70,9 @@ async function main() {
       }
     }
   });
-
-  console.log('WebSocket server running on port 4000');
+  server.listen(4000, () => {
+    console.log('WebSocket server running on port 4000');
+  });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- add an HTTP server with a `/health` endpoint for Docker health checks
- ensure Kafka topic exists before starting the consumer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0c76c758832782c9eae3c6caa6a7